### PR TITLE
Fixed news API

### DIFF
--- a/assets/js/news-api.js
+++ b/assets/js/news-api.js
@@ -1,7 +1,5 @@
 // api to fetch news from NY Times
 
-let searchedCountry = '';
-
 // variables: keywords, begin_date, end_date
 // * api
 const apiKey = "YfIUBElKGXDPyEkqeoTHKUNqWudUQyeC";


### PR DESCRIPTION
Removed a line in script js that was throwing an error as the variable was already defined in autocomplete.js